### PR TITLE
Fix macOS build

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -24,6 +24,8 @@ pub fn build(b: *std.build.Builder) void {
 
     lib.addIncludePath(.{ .cwd_relative = "postgres/src/include" });
     lib.linkLibC();
+    lib.linker_allow_shlib_undefined = true;
+
     // This declares intent for the library to be installed into the standard
     // location when the user invokes the "install" step (the default step when
     // running `zig build`).


### PR DESCRIPTION
When building on macOS, the linker complains about lots of undefined references:

```
error: undefined reference to symbol _pg_detoast_datum_packed
    note: referenced in /Users/penberg/src/tursodatabase/pg_turso/zig-cache/o/080fefbf7101dd23cb11670cb7cdcc39/libpg_turso.0.1.0.dylib.o
error: undefined reference to symbol _bms_free
    note: referenced in /Users/penberg/src/tursodatabase/pg_turso/zig-cache/o/080fefbf7101dd23cb11670cb7cdcc39/libpg_turso.0.1.0.dylib.o
error: undefined reference to symbol _pfree
    note: referenced in /Users/penberg/src/tursodatabase/pg_turso/zig-cache/o/080fefbf7101dd23cb11670cb7cdcc39/libpg_turso.0.1.0.dylib.o
error: undefined reference to symbol _get_rel_name
    note: referenced in /Users/penberg/src/tursodatabase/pg_turso/zig-cache/o/080fefbf7101dd23cb11670cb7cdcc39/libpg_turso.0.1.0.dylib.o
error: undefined reference to symbol _MemoryContextDelete
    note: referenced in /Users/penberg/src/tursodatabase/pg_turso/zig-cache/o/080fefbf7101dd23cb11670cb7cdcc39/libpg_turso.0.1.0.dylib.o
error: undefined reference to symbol _palloc0
```

Fix that by passing the `-fallow-shlib-undefined` flag to `zig build-lib`, which seems to be the canonical fix:

https://github.com/ziglang/zig/issues/8180